### PR TITLE
Fixes to title text, RSS URL, and description

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -26,7 +26,7 @@ class syntax_plugin_xkcd extends DokuWiki_Syntax_Plugin {
         'email'   => 'zaswiki@gmail.com',
         'date'    => '2013-04-16',
         'name'    => 'xkcd Plugin',
-        'desc'    => 'It displays the xkcd tree times a week. Using RSS feed',
+        'desc'    => 'It displays the xkcd three times a week. Using RSS feed',
         'url'     => 'https://xkcd.com/rss.xml'
         );
     }

--- a/syntax.php
+++ b/syntax.php
@@ -27,14 +27,14 @@ class syntax_plugin_xkcd extends DokuWiki_Syntax_Plugin {
         'date'    => '2013-04-16',
         'name'    => 'xkcd Plugin',
         'desc'    => 'It displays the xkcd treee times a week. Using RSS feed',
-        'url'     => 'http://xkcd.com/rss.xml'
+        'url'     => 'https://xkcd.com/rss.xml'
         );
     }
 
     private function _listhd() {
         require_once(DOKU_INC . 'inc/HTTPClient.php');
 
-        $url = 'http://xkcd.com/rss.xml';
+        $url = 'https://xkcd.com/rss.xml';
         $ch = new DokuHTTPClient();
         $piece = $ch->get($url);
         $xml = simplexml_load_string($piece);

--- a/syntax.php
+++ b/syntax.php
@@ -26,7 +26,7 @@ class syntax_plugin_xkcd extends DokuWiki_Syntax_Plugin {
         'email'   => 'zaswiki@gmail.com',
         'date'    => '2013-04-16',
         'name'    => 'xkcd Plugin',
-        'desc'    => 'It displays the xkcd treee times a week. Using RSS feed',
+        'desc'    => 'It displays the xkcd tree times a week. Using RSS feed',
         'url'     => 'https://xkcd.com/rss.xml'
         );
     }

--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_xkcd extends DokuWiki_Syntax_Plugin {
         $comicURL = $xml->channel->item->link;
 
         $description = (string) $xml->channel->item->description;
-        $description = html_entity_decode($description);
+        $description = html_entity_decode($description, ENT_NOQUOTES);
         $feed_contents = $description;
         // Not used anymore because of new xml format
         //$dom = new DOMDocument();


### PR DESCRIPTION
When the title text contained a double quote, it wouldn't be displayed properly, because the `&quot;` was being unescaped into `"`, causing malformed HTML and the title to be chopped off at this point. This pull request contains a fix for this. It also uses HTTPS instead of HTTP when retrieving the xkcd RSS feed, and corrects a typo in the description.
