### PR TITLE
Update syntax.php

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -63,11 +63,11 @@ class syntax_plugin_xkcd extends DokuWiki_Syntax_Plugin {
 
     function getSort() { return 667; }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         return array($match, $state, $pos);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
         if ($mode == 'xhtml') {
             $renderer->doc .= $this->_listhd();


### PR DESCRIPTION
Fixed compatibility error with newer versions of DokuWiki.
Without this fix, plugin would throw errors in apache2 error log.